### PR TITLE
Migrate specification content from CLAUDE.md to docs/design

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,18 +8,7 @@ shekere is a Rust-based creative coding tool that combines WebGPU-based fragment
 
 ## Core Architecture
 
-The application follows a modular architecture centered around the State pattern:
-
-- **State (`src/state.rs`)**: Central state management handling WebGPU setup, uniforms, and render loop
-- **Config (`src/config.rs`)**: TOML-based configuration system for window, shaders, OSC, and audio spectrum
-- **Uniforms (`src/uniforms/`)**: Modular uniform system with separate modules for different data types:
-  - `window_uniform.rs`: Window resolution data
-  - `time_uniform.rs`: Time-based animation data
-  - `mouse_uniform.rs`: Mouse position tracking
-  - `osc_uniform.rs`: OSC (Open Sound Control) integration for Tidalcycles
-  - `spectrum_uniform.rs`: Real-time audio spectrum analysis via FFT
-- **Pipeline (`src/pipeline.rs`)**: WebGPU render pipeline creation and shader compilation
-- **BindGroupFactory (`src/bind_group_factory.rs`)**: Dynamic bind group creation for different uniform combinations
+For detailed architecture specifications, see [docs/design/architecture.md](docs/design/architecture.md).
 
 ## Development Commands
 
@@ -63,55 +52,25 @@ cargo clippy --all-targets
 
 ## Configuration System
 
-The application uses TOML configuration files with the following structure:
-
-- **Required**: `[window]` section with width/height
-- **Required**: `[[pipeline]]` array with shader configuration
-- **Optional**: `[osc]` for OSC integration with sound mapping
-- **Optional**: `[spectrum]` for audio spectrum analysis
+For detailed configuration specifications, see [docs/design/configuration.md](docs/design/configuration.md).
 
 Example configuration files are in the `examples/` directory.
 
 ## Shader Development
 
-Fragment shaders are written in WGSL (WebGPU Shading Language) and must:
-- Use entry point `fs_main`
-- Accept `VertexOutput` struct with `@builtin(position)`
-- Return `@location(0) vec4<f32>` color output
-- Access uniforms through predefined binding groups:
-  - Group 0: Window and Time uniforms (always available)
-  - Group 1: Device uniforms (mouse, etc.)
-  - Group 2: Sound uniforms (OSC, spectrum, MIDI - when configured)
-- Use helper functions for uniform data access (e.g., `SpectrumAmplitude(i)`, `OscGain(i)`)
-- All sound uniforms use vec4 packing for WebGPU alignment optimization
+For shader development information, see [docs/guide.md](docs/guide.md) and [docs/api-reference.md](docs/api-reference.md).
 
 ## Audio Integration
 
-The application supports two audio input methods:
-
-1. **OSC Integration**: Receives OSC messages (typically from Tidalcycles) on configurable port
-2. **Spectrum Analysis**: Real-time FFT analysis of system audio input with configurable frequency range
-
-Both create GPU-accessible uniform data for shader consumption.
+For detailed audio integration specifications, see:
+- [OSC Integration](docs/design/osc.md)
+- [MIDI Integration](docs/design/midi.md)
+- [Spectrum Analysis](docs/design/spectrum.md)
 
 ## Hot Reload System
 
-The application includes a hot reload system for live coding:
+For detailed hot reload system specifications, see [docs/design/hot-reload.md](docs/design/hot-reload.md).
 
-- **File Watching**: Uses `notify` crate to monitor WGSL file changes
-- **Error Safety**: WGSL compilation errors and pipeline creation errors are caught using `std::panic::catch_unwind()`
-- **Graceful Degradation**: On error, the existing render pipeline is maintained and the application continues running
-- **Auto Recovery**: After file modification, automatic reload is attempted
-- **Configuration**: Enable with `[hot_reload] enabled = true`
-
-## Key Implementation Details
-
-- Uses `winit` for window management and input handling
-- WebGPU backend selection via feature flags (PRIMARY backends on desktop, GL on WASM)
-- Async initialization pattern for WebGPU setup
-- Real-time uniform updates in the render loop
-- Modular bind group system allows dynamic uniform combinations
-- Configuration file path determines shader file resolution directory
 
 ## Testing Requirements
 

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -1,0 +1,45 @@
+# Architecture Specification
+
+## Overview
+
+shekere is a Rust-based creative coding tool that combines WebGPU-based fragment shaders with audio integration (OSC and spectrum analysis). It creates real-time visual effects driven by sound and user interaction.
+
+## Core Architecture
+
+The application follows a modular architecture centered around the State pattern:
+
+### Core Components
+
+- **State (`src/state.rs`)**: Central state management handling WebGPU setup, uniforms, and render loop
+- **Config (`src/config.rs`)**: TOML-based configuration system for window, shaders, OSC, and audio spectrum
+- **Uniforms (`src/uniforms/`)**: Modular uniform system with separate modules for different data types:
+  - `window_uniform.rs`: Window resolution data
+  - `time_uniform.rs`: Time-based animation data
+  - `mouse_uniform.rs`: Mouse position tracking
+  - `osc_uniform.rs`: OSC (Open Sound Control) integration for Tidalcycles
+  - `spectrum_uniform.rs`: Real-time audio spectrum analysis via FFT
+- **Pipeline (`src/pipeline.rs`)**: WebGPU render pipeline creation and shader compilation
+- **BindGroupFactory (`src/bind_group_factory.rs`)**: Dynamic bind group creation for different uniform combinations
+
+## Key Implementation Details
+
+- Uses `winit` for window management and input handling
+- WebGPU backend selection via feature flags (PRIMARY backends on desktop, GL on WASM)
+- Async initialization pattern for WebGPU setup
+- Real-time uniform updates in the render loop
+- Modular bind group system allows dynamic uniform combinations
+- Configuration file path determines shader file resolution directory
+
+## Design Patterns
+
+### State Pattern
+The application uses a centralized state management pattern where the `State` struct manages all application state including WebGPU resources, uniforms, and render loop coordination.
+
+### Modular Uniforms
+The uniform system is designed to be modular, allowing different combinations of uniforms to be used based on configuration. This is achieved through:
+- Separate modules for each uniform type
+- Dynamic bind group creation based on enabled features
+- vec4 packing for WebGPU alignment optimization
+
+### Configuration-Driven Architecture
+The application structure is determined by TOML configuration files, allowing for flexible deployment scenarios without code changes.

--- a/docs/design/configuration.md
+++ b/docs/design/configuration.md
@@ -1,0 +1,55 @@
+# Configuration System Specification
+
+## Overview
+
+The application uses TOML configuration files to define application behavior, visual effects, and audio integration settings. The configuration system is designed to be flexible and extensible.
+
+## Configuration Structure
+
+### Required Sections
+
+#### `[window]`
+Defines the application window properties:
+- `width`: Window width in pixels
+- `height`: Window height in pixels
+
+#### `[[pipeline]]`
+Array of pipeline configurations for shader processing:
+- Shader configuration and compilation settings
+- Multiple pipelines can be defined for complex effects
+
+### Optional Sections
+
+#### `[osc]`
+OSC (Open Sound Control) integration for real-time audio control:
+- Port configuration for OSC message reception
+- Sound mapping configuration
+- Integration with tools like Tidalcycles
+
+#### `[spectrum]`
+Audio spectrum analysis configuration:
+- FFT-based real-time audio analysis
+- Configurable frequency range settings
+- System audio input processing
+
+#### `[hot_reload]`
+Live coding and development features:
+- `enabled`: Boolean flag to enable/disable hot reload
+- File watching for automatic shader recompilation
+
+## Configuration Resolution
+
+- Configuration file path determines shader file resolution directory
+- Relative paths in configuration are resolved relative to the config file location
+- Example configuration files are provided in the `examples/` directory
+
+## Design Principles
+
+### Flexibility
+The configuration system allows for various deployment scenarios without requiring code changes. Applications can be configured for different audio sources, visual effects, and interaction modes.
+
+### Extensibility
+New configuration sections can be added without breaking existing configurations. The modular design allows for future expansion of features.
+
+### Validation
+Configuration parsing includes validation to ensure required sections are present and values are within acceptable ranges.

--- a/docs/design/hot-reload.md
+++ b/docs/design/hot-reload.md
@@ -1,0 +1,78 @@
+# Hot Reload System Specification
+
+## Overview
+
+The hot reload system enables live coding and development workflows by automatically recompiling and reloading shaders when source files are modified. This system is designed for safety and reliability, ensuring the application continues running even when shader compilation fails.
+
+## Core Features
+
+### File Watching
+- Uses the `notify` crate to monitor WGSL file changes
+- Automatically detects file modifications in real-time
+- Supports multiple shader files simultaneously
+
+### Error Safety
+- WGSL compilation errors are caught using `std::panic::catch_unwind()`
+- Pipeline creation errors are handled gracefully
+- Error handling ensures the application never crashes due to shader issues
+
+### Graceful Degradation
+- On compilation error, the existing render pipeline is maintained
+- Application continues running with the last successful shader
+- Visual feedback or logging indicates compilation failures
+
+### Auto Recovery
+- After file modification, automatic reload is attempted
+- No manual intervention required for successful recompilation
+- Seamless transition to updated shaders when compilation succeeds
+
+## Configuration
+
+### Enable Hot Reload
+```toml
+[hot_reload]
+enabled = true
+```
+
+### Disable Hot Reload
+```toml
+[hot_reload]
+enabled = false
+```
+
+Or simply omit the `[hot_reload]` section entirely (defaults to disabled).
+
+## Development Workflow
+
+### Live Coding Support
+- Modify shader files in real-time
+- See changes reflected immediately in the application
+- Iterate quickly on visual effects without restarting
+
+### Error Handling Workflow
+1. Developer modifies shader file
+2. Hot reload system detects file change
+3. Shader compilation is attempted
+4. If successful: New pipeline is created and activated
+5. If failed: Error is logged, existing pipeline continues
+
+### Performance Considerations
+- File watching has minimal performance impact
+- Shader compilation only occurs on file changes
+- No impact on render loop performance
+
+## Implementation Details
+
+### Thread Safety
+- File watching runs on separate threads
+- Shader compilation is isolated from render thread
+- Thread-safe communication between file watcher and render loop
+
+### Memory Management
+- Old pipelines are properly cleaned up after successful recompilation
+- Resource management prevents memory leaks during development cycles
+
+### Integration with State Management
+- Hot reload integrates with the central State management system
+- Pipeline updates are coordinated with uniform updates
+- Maintains consistency between shader and uniform data

--- a/docs/design/midi.md
+++ b/docs/design/midi.md
@@ -1,0 +1,73 @@
+# MIDI Integration Specification
+
+## Overview
+
+MIDI integration enables real-time control through MIDI input devices. This system provides access to MIDI messages for creating interactive audio-visual experiences.
+
+## Purpose
+
+Receives MIDI messages from connected MIDI devices for real-time parameter control and musical interaction.
+
+## Features
+
+- **Device Input**: Support for MIDI input devices (keyboards, controllers, etc.)
+- **Real-time Processing**: Immediate response to MIDI messages
+- **Parameter Control**: Map MIDI data to shader parameters
+- **Musical Interaction**: Create music-responsive visual effects
+
+## Configuration
+
+```toml
+[midi]
+enabled = true
+```
+
+### Configuration Parameters
+
+- `enabled`: Boolean flag to enable/disable MIDI input processing
+
+## GPU Integration
+
+### Uniform Data Creation
+- MIDI data is processed and converted to GPU-accessible uniform buffers
+- Data is made available to shaders through binding group 2 (Sound Uniforms)
+- Real-time updates ensure smooth audio-visual synchronization
+
+### vec4 Packing Optimization
+- All MIDI uniforms use vec4 packing for WebGPU alignment
+- Ensures optimal memory layout for GPU processing
+- Improves performance by reducing memory bandwidth requirements
+
+## Shader Integration
+
+### Sound Uniforms (Binding Group 2)
+When MIDI is configured, shaders can access:
+- **MIDI Data**: Real-time MIDI message values
+- Note data, velocity information, and control changes
+
+### Helper Functions
+Shaders can use helper functions for MIDI data access. For detailed function signatures and usage, see [API Reference](api-reference.md).
+
+## Real-Time Processing
+
+### Performance Considerations
+- MIDI processing runs on separate threads to avoid blocking rendering
+- Efficient data structures for real-time message processing
+- Minimal latency between MIDI input and visual output
+
+### Synchronization
+- MIDI data is synchronized with the render loop
+- Thread-safe data structures for concurrent access
+- Consistent frame timing for smooth audio-visual effects
+
+## MIDI Protocol
+
+### Message Types
+- Support for standard MIDI message types (Note On/Off, Control Change, etc.)
+- Message parsing and validation
+- Device connection management
+
+### Device Management
+- Automatic detection of connected MIDI devices
+- Handle device connection/disconnection gracefully
+- Support for multiple MIDI input devices

--- a/docs/design/osc.md
+++ b/docs/design/osc.md
@@ -1,0 +1,87 @@
+# OSC Integration Specification
+
+## Overview
+
+OSC (Open Sound Control) integration enables real-time audio control through network messages. This system is designed for live coding performances and integration with external audio software.
+
+## Purpose
+
+Receives Open Sound Control (OSC) messages for real-time audio control and parameter manipulation.
+
+## Features
+
+- **Configurable Port**: Set custom port for OSC message reception
+- **Address Pattern Matching**: Filter OSC messages by address pattern
+- **Sound Mapping**: Configure sound names and IDs for parameter control
+- **Tidalcycles Integration**: Seamless integration with Tidalcycles for live coding performances
+- **Real-time Updates**: Immediate parameter updates from external audio software
+
+## Configuration
+
+```toml
+[osc]
+port = 2020
+addr_pattern = "/dirt/play"
+
+[[osc.sound]]
+name = "bd"
+id = 1
+
+[[osc.sound]]
+name = "sd"
+id = 2
+```
+
+### Configuration Parameters
+
+- `port`: UDP port number for OSC message reception
+- `addr_pattern`: OSC address pattern to match incoming messages
+- `sound[]`: Array of sound configurations
+  - `name`: Sound identifier name
+  - `id`: Numeric ID for shader uniform access
+
+## GPU Integration
+
+### Uniform Data Creation
+- OSC data is processed and converted to GPU-accessible uniform buffers
+- Data is made available to shaders through binding group 2 (Sound Uniforms)
+- Real-time updates ensure smooth audio-visual synchronization
+
+### vec4 Packing Optimization
+- All OSC uniforms use vec4 packing for WebGPU alignment
+- Ensures optimal memory layout for GPU processing
+- Improves performance by reducing memory bandwidth requirements
+
+## Shader Integration
+
+### Sound Uniforms (Binding Group 2)
+When OSC is configured, shaders can access:
+- **OSC Data**: Real-time OSC parameter values
+- Sound-specific parameters mapped by ID
+
+### Helper Functions
+Shaders can use helper functions for OSC data access. For detailed function signatures and usage, see [API Reference](api-reference.md).
+
+## Real-Time Processing
+
+### Performance Considerations
+- OSC processing runs on separate threads to avoid blocking rendering
+- Efficient data structures for real-time message processing
+- Minimal latency between OSC input and visual output
+
+### Synchronization
+- OSC data is synchronized with the render loop
+- Thread-safe data structures for concurrent access
+- Consistent frame timing for smooth audio-visual effects
+
+## Network Protocol
+
+### UDP Communication
+- Uses UDP protocol for low-latency message transmission
+- Handles message parsing and validation
+- Supports standard OSC message format
+
+### Message Processing
+- Incoming messages are filtered by address pattern
+- Sound parameters are extracted and mapped to uniform data
+- Invalid messages are discarded gracefully

--- a/docs/design/spectrum.md
+++ b/docs/design/spectrum.md
@@ -1,0 +1,84 @@
+# Spectrum Analysis Specification
+
+## Overview
+
+Spectrum analysis provides real-time FFT (Fast Fourier Transform) analysis of system audio input. This system enables audio-reactive visual effects based on frequency domain analysis.
+
+## Purpose
+
+Real-time FFT analysis of system audio input for frequency-based visual effects and music visualization.
+
+## Features
+
+- **FFT-based Analysis**: Frequency domain analysis of audio input
+- **Configurable Frequency Range**: Set minimum and maximum frequency bounds
+- **Configurable Sampling Rate**: Adjust sampling rate for analysis precision
+- **System Audio Input**: Process audio from system audio input
+- **Real-time Processing**: Continuous spectrum data for visual effects
+
+## Configuration
+
+```toml
+[spectrum]
+min_frequency = 20.0
+max_frequency = 20000.0
+sampling_rate = 44100
+```
+
+### Configuration Parameters
+
+- `min_frequency`: Minimum frequency (Hz) for analysis range
+- `max_frequency`: Maximum frequency (Hz) for analysis range  
+- `sampling_rate`: Audio sampling rate for FFT analysis
+
+## GPU Integration
+
+### Uniform Data Creation
+- Spectrum data is processed and converted to GPU-accessible uniform buffers
+- Data is made available to shaders through binding group 2 (Sound Uniforms)
+- Real-time updates ensure smooth audio-visual synchronization
+
+### vec4 Packing Optimization
+- All spectrum uniforms use vec4 packing for WebGPU alignment
+- Ensures optimal memory layout for GPU processing
+- Improves performance by reducing memory bandwidth requirements
+
+## Shader Integration
+
+### Sound Uniforms (Binding Group 2)
+When spectrum analysis is configured, shaders can access:
+- **Spectrum Data**: Frequency domain analysis results
+- Amplitude data for specific frequency ranges
+
+### Helper Functions
+Shaders can use helper functions for spectrum data access. For detailed function signatures and usage, see [API Reference](api-reference.md).
+
+## Real-Time Processing
+
+### Performance Considerations
+- Audio processing runs on separate threads to avoid blocking rendering
+- Efficient FFT algorithms for real-time analysis
+- Optimized data structures for frequency domain processing
+- Minimal latency between audio input and visual output
+
+### Synchronization
+- Spectrum data is synchronized with the render loop
+- Thread-safe data structures for concurrent access
+- Consistent frame timing for smooth audio-visual effects
+
+## Audio Processing
+
+### FFT Analysis
+- Uses Fast Fourier Transform for frequency domain conversion
+- Configurable window size and overlap for analysis precision
+- Handles audio input buffering and processing
+
+### Frequency Range Processing
+- Filters analysis results to configured frequency range
+- Maps frequency bins to uniform array indices
+- Provides amplitude data for specified frequency bands
+
+### System Audio Input
+- Captures audio from system audio input devices
+- Handles audio device selection and management
+- Supports various audio formats and sample rates


### PR DESCRIPTION
Create dedicated specification documents for each functional area:
- docs/design/architecture.md for core architecture specifications
- docs/design/configuration.md for configuration system specifications
- docs/design/osc.md for OSC integration specifications
- docs/design/midi.md for MIDI integration specifications
- docs/design/spectrum.md for spectrum analysis specifications
- docs/design/hot-reload.md for hot reload system specifications

Update CLAUDE.md to reference individual specification documents instead of containing detailed specifications.

This improves documentation organization by separating development guidance from functional specifications.

🤖 Generated with [Claude Code](https://claude.ai/code)